### PR TITLE
Sitemap appearance fix

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -3,7 +3,5 @@ use RainLab\Sitemap\Models\Definition;
 
 Route::get('sitemap.xml', function (){
 
-    header("Content-Type: application/xml");
-    return Definition::first()->generateSitemap();
-
+    return Response::make(Definition::first()->generateSitemap(), 200, array('Content-Type' => 'application/xml'));
 });


### PR DESCRIPTION
The request to /sitemap.xml did not return an application/xml content type object but instead returned plain text. This commit fixes that issue.