### PR TITLE
Fixed select active Theme and Added Spanish language translations

### DIFF
--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'plugin' => [
+        'name' => 'Sitemap (mapa del sitio)',
+        'description' => 'Generar un fichero sitemap.xml para tu sitio web.'
+    ],
+    'item' => [
+        'location' => 'Localización',
+        'priority' => 'Prioridad',
+        'changefreq' => 'Frecuencia de cambio',
+        'always' => 'siempre',
+        'hourly' => 'A cada hora',
+        'daily' => 'Diariamente',
+        'weekly' => 'Semanalmente',
+        'monthly' => 'Mensualmente',
+        'yearly' => 'Anualmente',
+        'never' => 'nunca',
+        'editor_title' => 'Edita el elemento del Sitemap',
+        'type' => 'Tipo',
+        'allow_nested_items' => 'Permitir elemento anidados',
+        'allow_nested_items_comment' => 'Los elementos anidados podrán ser generados dinámicamente por páginas estáticas y otros tipos de elementos',
+        'url' => 'URL',
+        'reference' => 'Referencia',
+        'title_required' => 'El título es requerido',
+        'unknown_type' => 'Tipo de elemento desconocido',
+        'unnamed' => 'Elemento sin nombre',
+        'add_item' => 'Añadir <u>E</u>lemento',
+        'new_item' => 'Nuevo elemento',
+        'cms_page' => 'CMS Página',
+        'cms_page_comment' => 'Seleccione la página a usar para la dirección URL.',
+        'reference_required' => 'La referencia al elemento es requerida.',
+        'url_required' => 'La URL es requerida',
+        'cms_page_required' => 'Por favor seleccione una CMS página',
+        'page' => 'Página',
+        'url' => 'URL',
+        'check' => 'Verificar'
+    ]
+];

--- a/routes.php
+++ b/routes.php
@@ -1,9 +1,12 @@
 <?php
 use RainLab\Sitemap\Models\Definition;
+use Cms\Classes\Theme;
 
 Route::get('sitemap.xml', function (){
+	
+	$themeActive = Theme::getActiveTheme()->getDirName();
 
-    return Response::make(Definition::first()->generateSitemap())
+    return Response::make(Definition::where('theme','=',$themeActive)->firstOrFail()->generateSitemap())
         ->header("Content-Type", "application/xml");
 
 });


### PR DESCRIPTION
There is a problem in the project when there are several themes installed, the plugin always  generates the sitemap from the first theme returned by the database

In routes.php

Definition::first()->generateSitemap()

One solution is in the commit.

I also want to help with translation into Spanish language