### PR TITLE
Replaced the 500 error with 404 when no definition is found

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -42,5 +42,8 @@ return [
         'save_definition' => 'Saving Definition...',
         'load_indicator' => 'Emptying Definition...',
         'empty_confirm' => 'Empty this definition?'
+    ],
+    'definition' => [
+        'not_found' => 'No sitemap definition was found. Try creating one first.'
     ]
 ];

--- a/routes.php
+++ b/routes.php
@@ -1,12 +1,22 @@
 <?php
 
 use Cms\Classes\Theme;
+use Cms\Classes\Controller;
 use RainLab\Sitemap\Models\Definition;
+use Illuminate\Database\Eloquent\ModelNotFoundException as ModelNotFound;
 
 Route::get('sitemap.xml', function()
 {
     $themeActive = Theme::getActiveTheme()->getDirName();
 
-    return Response::make(Definition::where('theme', $themeActive)->firstOrFail()->generateSitemap())
+    try {
+    	$definition = Definition::where('theme', $themeActive)->firstOrFail();
+    } catch (ModelNotFound $e) {
+    	Log::info(trans('rainlab.sitemap::lang.definition.not_found'));
+
+    	return App::make(Controller::class)->setStatusCode(404)->run('/404');
+    }
+
+    return Response::make($definition->generateSitemap())
         ->header("Content-Type", "application/xml");
 });


### PR DESCRIPTION
I have replaced the 500 error when no sitemap definition is found with a 404 error page. There is also a log message to explain this caught exception.