### PR TITLE
Alternate language pages

### DIFF
--- a/models/Definition.php
+++ b/models/Definition.php
@@ -99,19 +99,13 @@ class Definition extends Model
              */
             else {
 
-                if (class_exists('\RainLab\Translate\Classes\Translator')){
-                    $translator = \RainLab\Translate\Classes\Translator::instance();
-                    $enabledLocales = \RainLab\Translate\Models\Locale::listEnabled();
-                } else {
-                    $enabledLocales = array('' => '');
+                $apiResult = Event::fire('pages.menuitem.resolveItem', [$item->type, $item, $currentUrl, $theme]);
+
+                if (!is_array($apiResult)) {
+                    continue;
                 }
 
-                foreach ($enabledLocales as $locale => $nothing) {
-
-                    if (!empty($locale)) $translator->setlocale($locale, false);
-
-                    $itemInfo = Event::fire('pages.menuitem.resolveItem', [$item->type, $item, $currentUrl, $theme], true);
-
+                foreach ($apiResult as $itemInfo) {
                     if (!is_array($itemInfo)) {
                         continue;
                     }

--- a/models/Definition.php
+++ b/models/Definition.php
@@ -99,13 +99,19 @@ class Definition extends Model
              */
             else {
 
-                $apiResult = Event::fire('pages.menuitem.resolveItem', [$item->type, $item, $currentUrl, $theme]);
-
-                if (!is_array($apiResult)) {
-                    continue;
+                if (class_exists('\RainLab\Translate\Classes\Translator')){
+                    $translator = \RainLab\Translate\Classes\Translator::instance();
+                    $enabledLocales = \RainLab\Translate\Models\Locale::listEnabled();
+                } else {
+                    $enabledLocales = array('' => '');
                 }
 
-                foreach ($apiResult as $itemInfo) {
+                foreach ($enabledLocales as $locale => $nothing) {
+
+                    if (!empty($locale)) $translator->setlocale($locale, false);
+
+                    $itemInfo = Event::fire('pages.menuitem.resolveItem', [$item->type, $item, $currentUrl, $theme], true);
+
                     if (!is_array($itemInfo)) {
                         continue;
                     }


### PR DESCRIPTION
Following thread in https://github.com/rainlab/sitemap-plugin/pull/52

Sitemap with alternate language pages as recommended by Google https://support.google.com/webmasters/answer/2620865?hl=en

This sitemap is generated with this modifications https://utopigstudio.com/sitemap.xml and Google Search Console says its ok, but it needs testing and validation because I'm not a sitemap/seo/xml expert at all.

    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
        <url>
            <loc>https://utopigstudio.com</loc>
            <lastmod>2017-10-08T19:44:44+00:00</lastmod>
            <changefreq>always</changefreq>
            <priority>1.0</priority>
            <xhtml:link rel="alternate" hreflang="en" href="https://utopigstudio.com/en" />
            <xhtml:link rel="alternate" hreflang="ca" href="https://utopigstudio.com/ca" />
        </url>
        <url>
            <loc>https://utopigstudio.com/prueba</loc>
            <lastmod>2017-10-19T20:20:55+00:00</lastmod>
            <changefreq>always</changefreq>
            <priority>0.1</priority>
            <xhtml:link rel="alternate" hreflang="en" href="https://utopigstudio.com/en/test" />
            <xhtml:link rel="alternate" hreflang="ca" href="https://utopigstudio.com/ca/prova" />
        </url>
    </urlset>

