### PR TITLE
Add configurable behavior for custom plugin pages

### DIFF
--- a/classes/CustomItemTypes.php
+++ b/classes/CustomItemTypes.php
@@ -6,6 +6,28 @@ use Cms\Classes\Page as CmsPage;
 use Symfony\Component\Yaml\Yaml;
 use Cms\Classes\Theme;
 
+/*
+
+    How to use:
+
+    Add the following lines to your model:
+    
+    public $itemTypeConfig = '/{author}/{plugin}/models/{model}/config_itemtypes.yaml';
+    public $implment = [
+        'RainLab.Sitemap.Classes.CustomItemTypes'
+    ];
+
+    ItemTypes.yaml:
+
+    apartment:
+      component: apartment <-- Component name
+      paramName: slug <-- Paramname on page
+      slug: slug <-- Model Slug
+      scope: isVisible <-- Custom Scope (optional)
+      dynamic: false
+
+*/
+
 class CustomItemTypes extends \October\Rain\Extension\ExtensionBase
 {
     protected $parent;

--- a/classes/CustomItemTypes.php
+++ b/classes/CustomItemTypes.php
@@ -139,9 +139,9 @@ class CustomItemTypes extends \October\Rain\Extension\ExtensionBase
 
         $items = new $this->parent;
 
-        if(isset($itemType['scope']))
+        if($scope)
         {
-            $items = $items->isVisible();
+            $items = $items->$scope();
         }
 
         $items = $items->orderBy('title')->get();

--- a/classes/CustomItemTypes.php
+++ b/classes/CustomItemTypes.php
@@ -1,0 +1,205 @@
+<?php namespace RainLab\Sitemap\Classes;
+
+use File;
+use Url;
+use Cms\Classes\Page as CmsPage;
+use Symfony\Component\Yaml\Yaml;
+use Cms\Classes\Theme;
+
+class CustomItemTypes extends \October\Rain\Extension\ExtensionBase
+{
+    protected $parent;
+
+    protected $itemTypes;
+
+    public function __construct($parent)
+    {
+        $this->parent = $parent;
+        $configPath = plugins_path($this->parent->itemTypeConfig);
+        $this->itemTypes = Yaml::parse(File::get($configPath));
+    }
+
+   public function getMenuTypeInfo($type)
+   {
+       $result = [];
+
+       if(! array_key_exists($type, $this->itemTypes))
+       {
+            return;
+       }
+       
+       $itemType = $this->getItemTypeOptions($type);
+       
+       
+       if (! $itemType['dynamic']) {
+
+            $references = [];
+            $items = $this->parent::orderBy($itemType['orderBy'])->get();
+
+            foreach ($items as $item) {
+                $references[$item->id] = $item->title;
+            }
+            $result = [
+                'references'   => $references,
+                'nesting'      => false,
+                'dynamicItems' => false
+            ];
+
+       }
+       if ($itemType['dynamic']) {
+           $result = [
+               'dynamicItems' => true
+           ];
+       }
+       if ($result) {
+           $theme = Theme::getActiveTheme();
+           $pages = CmsPage::listInTheme($theme, true);
+           $cmsPages = [];
+           foreach ($pages as $page) {
+               if (!$page->hasComponent($itemType['component'])) {
+                   continue;
+               }
+
+               $cmsPages[] = $page;
+           }
+           $result['cmsPages'] = $cmsPages;
+       }
+
+
+       return $result;
+   }
+
+   public function resolveMenuItem($item, $url, $theme)
+   {
+        $result = null;
+        if (!$item->cmsPage)
+        {
+            return;
+        }
+            
+        $page = CmsPage::loadCached($theme, $item->cmsPage);
+        if (!$page)
+        {
+            return;
+        }
+            
+        if (array_key_exists($item->type, $this->itemTypes)) {
+            
+            $itemType = $this->getItemTypeOptions($item->type);
+
+            $paramName = $itemType['paramName'];
+                        
+            if (!$paramName)
+            {
+                return;
+            }
+
+            if($itemType['dynamic'])
+            {
+                
+                $result = $this->getDynamicItems($itemType, $paramName, $page, $url);
+            }else{
+
+                $result = $this->getItemByReference($item, $itemType, $paramName, $page, $url);  
+            }
+        }
+
+       return $result;
+   }
+
+   protected function getDynamicItems($itemType, $paramName, $page, $url)
+   {
+        $result = [
+            'items' => []
+        ];
+
+        $scope = $itemType['scope'];
+
+        $items = new $this->parent;
+
+        if(isset($itemType['scope']))
+        {
+            $items = $items->isVisible();
+        }
+
+        $items = $items->orderBy('title')->get();
+
+        foreach ($items as $item) {
+            $result['items'][] = self::getModelMenuItem($page, $item, $paramName, $url, $itemType['slug']);
+        }
+
+        return $result;
+   }
+
+   protected function getItemByReference($item, $itemType, $paramName, $page, $url)
+   {
+        if (!$item->reference)
+        {
+            return;
+        }
+            
+        $model = $this->parent::find($item->reference);
+        if (!$model)
+        {
+            return;
+        }
+            
+        $result = self::getModelMenuItem($page, $model, $paramName, $url, $itemType['slug']);
+
+        return $result;
+
+   }
+
+    /**
+     * Returns an array of the specified item type.
+     * Optional field are merged or overwritten here.
+     *
+     * @param $itemType
+    */
+   protected function getItemTypeOptions($itemType)
+   {
+       $options = array_merge([
+           'paramName' => 'slug',
+           'slug' => 'slug',
+           'scope' => 'isVisible',
+           'orderBy' => 'title',
+           'dynamic' =>  null,
+       ], $this->itemTypes[$itemType]);
+
+       return $options;
+   }
+
+   /**
+    * Returns URL of a apartment page.
+    *
+    * @param $page
+    * @param $model
+    * @param $paramName
+    */
+   protected function getModelPageUrl($page, $model, $paramName, $slug)
+   {
+       $url = CmsPage::url($page->getBaseFileName(), [$paramName => $model->slug]);
+       if (!$url)
+           return;
+
+       $url = Url::to($url);
+
+       return $url;
+   }
+   
+   protected function getModelMenuItem($page, $item, $paramName, $url, $slug)
+   {
+        $result = [];
+
+        $pageUrl = self::getModelPageUrl($page, $item, $paramName, $slug);
+
+        $result['title'] = $item->title;
+        $result['url'] = $pageUrl;
+        $result['isActive'] = $pageUrl == $url;
+        $result['mtime'] = $item->updated_at;
+        return $result;
+   }
+
+}
+
+// Model Menu Item ML


### PR DESCRIPTION
This PR adds a new behavior to the Sitemap plugin that takes care of custom post type definitions by using a YAML file. 

If you have multiple custom plugins on your website which all generate custom pages, you will need to add them to the sitemap. In order to do this you will need to implement the same code with minor modifications like the component-name, slug or scope over and over again. This does not feel like the October magic we are used to. 

This behavior tries to implement some October magic by adding a behavior to the sitemap plugin which relies on a config.yaml that defines the sitemap-definitions. 

However, this PR is not a fix-it-all for all custom plugin sitemaps. It acts as a configurable solution for  tedious code duplication.

Not sure if the choice for using a `Behavior` is correct here. Feel free to give suggestions of you like, it works, but is not a finished PR. 

## ToDo
- [x] Provide Proof of Concept
- [ ] Implement Multilanguage (already tested, waiting on #55 )
- [ ] Clean code of unnecessary items/junk
- [ ] Debate whether a behavior is the correct choice here
- [ ] Search for issues
- [ ] Simplify registering of Sitemap events (?)
- [ ] Write ReadMe

## Known Issues/
- [ ] Scope has to be declared (will fix)

### When to use
-  When you have custom pages with one slug that need a sitemap

### When not to use
- When you have multiple slugs
- When sitemap is generated by a relation (as in RainLab.Blog)

## How to use
In order for this to work we need to add the following lines to the model

```php
public $itemTypeConfig = '{plugin}/{name}/models/{model}/{config}.yaml'
public $implement = ['RainLab.Sitemap.Classes.CustomItemTypes'];
```

Next we need to add a YAML config file at the defined location

```yaml
portfolio-item:
  # Component name that belongs to the post-type
  component: portfolioItem 
  # Parameter name of the CmsPage
  paramName: slug
  # Field name of the model slug
  slug: slug
  # Custom scope 
  scope: isPublished
  # Dynamic definition (true for all, false for item by reference)
  dynamic: false
```

