### PR TITLE
Update SitemapItems.php

### DIFF
--- a/formwidgets/SitemapItems.php
+++ b/formwidgets/SitemapItems.php
@@ -61,7 +61,7 @@ class SitemapItems extends FormWidgetBase
 
         $this->vars['emptyItem'] = $emptyItem;
 
-        $widgetConfig = $this->makeConfig('~/plugins/rainlab/sitemap/classes/definitionitem/fields.yaml');
+        $widgetConfig = $this->makeConfig('$/rainlab/sitemap/classes/definitionitem/fields.yaml');
         $widgetConfig->model = $sitemapItem;
         $widgetConfig->alias = $this->alias.'SitemapItem';
 


### PR DESCRIPTION
Fixed symbol path to DefinitionItem/fields.yaml configuration.
such a path should be more accurate than the path relative to the root