### PR TITLE
fix test preventing exception to be thrown

### DIFF
--- a/formwidgets/SitemapItems.php
+++ b/formwidgets/SitemapItems.php
@@ -103,7 +103,7 @@ class SitemapItems extends FormWidgetBase
             $this->typeInfoCache[$item->type] = SitemapItem::getTypeInfo($item->type);
         }
 
-        if (isset($this->typeInfoCache[$item->type])) {
+        if (isset($this->typeListCache[$item->type])) {
             $result = trans($this->typeListCache[$item->type]);
 
             if ($item->type !== 'url') {


### PR DESCRIPTION
prevent Exception when a typeList item is in the config but is not registered
(e.g. plugin that registered it has been disabled) 