### PR TITLE
[WIP] Make Sitemap plugin more extensible

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,5 +1,6 @@
 <?php namespace RainLab\Sitemap;
 
+use App;
 use Backend;
 use System\Classes\PluginBase;
 use System\Classes\SettingsManager;
@@ -23,6 +24,13 @@ class Plugin extends PluginBase
             'icon'        => 'icon-sitemap',
             'homepage'    => 'https://github.com/rainlab/sitemap-plugin'
         ];
+    }
+
+    public function register()
+    {
+        App::singleton('sitemap.definition', function() {
+            return Models\Definition::class;
+        });
     }
 
     /**

--- a/models/Definition.php
+++ b/models/Definition.php
@@ -92,7 +92,7 @@ class Definition extends Model
              * Explicit URL
              */
             if ($item->type == 'url') {
-                $this->addItemToSet($item, Url::to($item->url));
+                $this->addItemToSet($item);
             }
             /*
              * Registered sitemap type
@@ -114,7 +114,7 @@ class Definition extends Model
                      * Single item
                      */
                     if (isset($itemInfo['url'])) {
-                        $this->addItemToSet($item, $itemInfo['url'], array_get($itemInfo, 'mtime'));
+                        $this->addItemToSet($item, $itemInfo);
                     }
 
                     /*
@@ -128,7 +128,7 @@ class Definition extends Model
                         {
                             foreach ($items as $item) {
                                 if (isset($item['url'])) {
-                                    $this->addItemToSet($parentItem, $item['url'], array_get($item, 'mtime'));
+                                    $this->addItemToSet($parentItem, $item);
                                 }
 
                                 if (isset($item['items'])) {
@@ -148,6 +148,7 @@ class Definition extends Model
         $urlSet = $this->makeUrlSet();
         $xml = $this->makeXmlObject();
         $xml->appendChild($urlSet);
+        $xml->formatOutput = true;
 
         return $xml->saveXML();
     }
@@ -179,10 +180,21 @@ class Definition extends Model
         return $this->urlSet = $urlSet;
     }
 
-    protected function addItemToSet($item, $url, $mtime = null)
+    protected function addItemToSet($item, $itemInfo = null)
     {
+        $mtime = null;
+        if ($itemInfo && isset($itemInfo['mtime'])) {
+            $mtime = $itemInfo['mtime'];
+        }
+
         if ($mtime instanceof \DateTime) {
             $mtime = $mtime->getTimestamp();
+        }
+
+        if ($item->type == 'url') {
+            $url = Url::to($item->url);
+        } else {
+            $url = $itemInfo['url'];
         }
 
         $xml = $this->makeXmlObject();

--- a/routes.php
+++ b/routes.php
@@ -2,15 +2,15 @@
 
 use Cms\Classes\Theme;
 use Cms\Classes\Controller;
-use RainLab\Sitemap\Models\Definition;
 use Illuminate\Database\Eloquent\ModelNotFoundException as ModelNotFound;
+use Illuminate\Support\Facades\App;
 
 Route::get('sitemap.xml', function()
 {
     $themeActive = Theme::getActiveTheme()->getDirName();
 
     try {
-        $definition = Definition::where('theme', $themeActive)->firstOrFail();
+        $definition = App::make('sitemap.definition')::where('theme', $themeActive)->firstOrFail();
     }
     catch (ModelNotFound $e) {
         Log::info(trans('rainlab.sitemap::lang.definition.not_found'));


### PR DESCRIPTION
- register and use 'sitemap.definition' App singleton to allow Definition class extensibility
- fire 'rainlab.sitemap.extendUrlSet' event to allow extending the urlSet
- fire 'rainlab.sitemap.overrideAddItemToSet' to allow overriding addItemToSet() method
- make addItemToset() method more flexible